### PR TITLE
Block and Main Signal Regex Updates

### DIFF
--- a/smo-backend/src/analytics/signal-utils.ts
+++ b/smo-backend/src/analytics/signal-utils.ts
@@ -11,7 +11,7 @@ const logger = new ModuleLogger("SIGNALS-PROC-WORKER");
  * "L1_1A" matches the pattern.
  * "L23_456B" matches the pattern.
  */
-export const BLOCK_SIGNAL_REGEX = /^\w\d+_\d+[A-Z]*$/;
+export const BLOCK_SIGNAL_REGEX = /^L\d+_\d+[A-Z]*$/;
 
 /**
  * Regular expression to match the reverse block signal pattern.
@@ -20,7 +20,17 @@ export const BLOCK_SIGNAL_REGEX = /^\w\d+_\d+[A-Z]*$/;
  * "L1_1A" matches the pattern.
  * "L23_456B" matches the pattern.
  */
-export const BLOCK_SIGNAL_REVERSE_REGEX = /^\w\d+_\d+[A-Z]$/;
+export const BLOCK_SIGNAL_REVERSE_REGEX = /^L\d+_\d+[A-Z]$/;
+
+/**
+ * Regular expression to match the main signal pattern.
+ * The pattern is one or more word characters followed by an underscore and one or more word characters or digits.
+ * The first word character can be any uppercase or lowercase letter except "L" since it is reserved for block signals.
+ * @example
+ * "ZW_D" matches the pattern.
+ * "ZW_1" matches the pattern.
+ */
+export const MAIN_SIGNAL_REGEX = /[A-KM-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ]+(\d+)?_[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ0-9]+/;
 
 /**
  * Function to determine the type of signal for a given train.
@@ -33,6 +43,10 @@ export const BLOCK_SIGNAL_REVERSE_REGEX = /^\w\d+_\d+[A-Z]$/;
  */
 export function getSignalType(train: Train) {
   if (train.TrainData.SignalInFrontSpeed === 60 || train.TrainData.SignalInFrontSpeed === 100) {
+    return "main";
+  }
+
+  if (MAIN_SIGNAL_REGEX.test(train.TrainData.SignalInFront.split("@")[0])) {
     return "main";
   }
 

--- a/smo-backend/src/analytics/signal-utils.ts
+++ b/smo-backend/src/analytics/signal-utils.ts
@@ -30,7 +30,7 @@ export const BLOCK_SIGNAL_REVERSE_REGEX = /^L\d+_\d+[A-Z]$/;
  * "ZW_D" matches the pattern.
  * "ZW_1" matches the pattern.
  */
-export const MAIN_SIGNAL_REGEX = /[A-KM-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ]+(\d+)?_[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ0-9]+/;
+export const MAIN_SIGNAL_REGEX = /[A-KM-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ][A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ]+(\d+)?_[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ0-9]+/;
 
 /**
  * Function to determine the type of signal for a given train.


### PR DESCRIPTION
Block signal regex updated and main signal regex added with following conditions:

- Block signals start with the letter "L" so added.
- Main signals now can pick up Polish letters automatically by following this rule: All letters except "L"(case sensitive) single time, followed by all letters, followed by numbers, followed by single "_", followed by all letters and numbers.
  - Examples being: Zw_M, Spł1_C, etc.