### PR TITLE
Fixes in Turkish translations

### DIFF
--- a/smo-frontend/src/assets/translations.json
+++ b/smo-frontend/src/assets/translations.json
@@ -622,11 +622,11 @@
           "Description": "Haritada trenleri takip etmek için alternatif bir yöntem kullanın. Bu yöntem daha az pürüzsüz olabilir ancak daha az CPU kullanır."
         },
         "disableSlidingMarkers": {
-          "Label": "Kaydırma işaretlerini devre dışı bırak",
-          "Description": "Trenler için kaydırma işaretlerini devre dışı bırakın. Bu, bazı cihazlarda performansı artırabilir."
+          "Label": "Kayan işaretçileri devre dışı bırak",
+          "Description": "Trenler için kayan işaret animasyonlarını devre dışı bırakın. Bu, bazı cihazlarda performansı artırabilir."
         },
         "passiveSignalOpacity": {
-          "Label": "Pasif sinyal katmanı opaklığı"
+          "Label": "Pasif sinyal katman opaklığı"
         },
         "TrainWindow": "Tren Penceresi",
         "expandScheduleDefault": {
@@ -767,7 +767,7 @@
       "LowSpeedWarning": {
         "Title": "Düşük ortalama tren hızı",
         "Description": "Bu sunucudaki trenlerin ortalama hızı {{speed}} km/s.",
-        "Tooltip": "İpucu: Bu uyarıyı ayarlarda kapatabilirsiniz."
+        "Tooltip": "İpucu: Bu uyarıyı ayarlardan kapatabilirsiniz."
       }
     }
   },

--- a/smo-frontend/src/assets/translations.json
+++ b/smo-frontend/src/assets/translations.json
@@ -626,7 +626,7 @@
           "Description": "Trenler için kayan işaret animasyonlarını devre dışı bırakın. Bu, bazı cihazlarda performansı artırabilir."
         },
         "passiveSignalOpacity": {
-          "Label": "Pasif sinyal katman opaklığı"
+          "Label": "Pasif sinyal katmanı opaklığı"
         },
         "TrainWindow": "Tren Penceresi",
         "expandScheduleDefault": {


### PR DESCRIPTION
Explanations:

Sliding markers do not make sense in the current way. It took me some time to realise that they disable the moving animations. I refactored the wording accordingly to explicitly tell that it toggles the animation.
- On low speed warning, wording corrected.